### PR TITLE
Added support for mapping doc tags, doclet modes and some doclet tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 #ApiFest Doclet
-ApiFest Doclet is a tool that generates ApiFest mapping configuration file (XML) from Javadoc.
+ApiFest Doclet is a tool that generates ApiFest mapping configuration file (XML) from Javadoc. ApiFest Doclet supports two modes: "mapping" and "doc". When using
+the first mode the doclet is generating a XML file containing the mapping endpoints. In the second mode the Doclet generates a json file that contains documentation for every endpoint.
 Here are the custom Javadoc annotations that ApiFest Doclet is aware of:
 
 - @apifest.external - the endpoint visible to the world;
@@ -11,7 +12,9 @@ Here are the custom Javadoc annotations that ApiFest Doclet is aware of:
 Note, that if the endpoint could be accessible without access token, then just skip this tag;
 - @apifest.re.{varName} - regular expression used for variable with name {varName} (without brackets); if several variables, then
 add @apifest.re.{varName} for each of them.
-
+- @apifest.docs.description - long text description for the endpoint. 
+- @apifest.docs.summary - short text description for the endpoint.
+- @apifest.docs.group - can be used to group endpoints.
 
 Currently, JAX-RS HTTP method annotations are used for setting the HTTP method of the endpoint.
 
@@ -26,15 +29,25 @@ Currently, JAX-RS HTTP method annotations are used for setting the HTTP method o
 ###Usage
 ApiFest Doclet requires the following environment variables:
 
+For both modes:
+
+- mode - the Doclet support two modes in the moment ("mapping" and "doc").They can be comma separated.
 - mapping.version - the version your API will be exposed externally;
+- application.path - the application path used to obtain all application resources, it will be preprended to each internal path;
+
+Only for the Doclet "mapping" mode:
+
 - mapping.filename - the name of the mapping configuration file that will be generated;
 - backend.host - the host(your API is running on) where requests should be translated to;
 - backend.port - the port of the backend.host;
-- application.path - the application path used to obtain all application resources, it will be preprended to each internal path;
 - defaultActionClass - the fully qualified action class that will be added if no action is declared in Javadoc annotations;
 - defaultFilterClass - the fully qualified filter class that will be added if no filter is declared in Javadoc annotations.
 
-If your project uses maven, here is an example integration of ApiFest Doclet in your pom.xml:
+Only for the Doclet "doc" mode:
+
+- mapping.docs.filename - the name of the mapping documentation file that will be generated.
+
+If your project uses maven, here is an example integration of ApiFest Doclet in "mapping" mode in your pom.xml:
 ```
 ...
 <profiles>
@@ -85,6 +98,7 @@ If your project uses maven, here is an example integration of ApiFest Doclet in 
                     <additionalJOption>-J-Dapplication.path=${application.path}</additionalJOption>
                     <additionalJOption>-J-DdefaultActionClass=${defaultActionClass}</additionalJOption>
                     <additionalJOption>-J-DdefaultFilterClass=${defaultFilterClass}</additionalJOption>
+                    <additionalJOption>-J-Dmode=${mode}</additionalJOption>
                   </additionalJOptions>
                   <useStandardDocletOptions>false</useStandardDocletOptions>
                 </configuration>
@@ -98,7 +112,7 @@ If your project uses maven, here is an example integration of ApiFest Doclet in 
 ...
 ```
 
-where *backend.host* and *backend.port* are defined in *project.properties* file; *mapping.version* and *mapping.filename* 
+where *backend.host*, *backend.port* and *mode* are defined in *project.properties* file; *mapping.version* and *mapping.filename* 
 could be defined in your pom.xml file so they stick to the code. *application.path* is the application path used to 
 obtain all application resources.
 Then you can use the following command in order to generate mapping xml file:

--- a/README.md
+++ b/README.md
@@ -3,18 +3,20 @@ ApiFest Doclet is a tool that generates ApiFest mapping configuration file (XML)
 the first mode the doclet is generating a XML file containing the mapping endpoints. In the second mode the Doclet generates a json file that contains documentation for every endpoint.
 Here are the custom Javadoc annotations that ApiFest Doclet is aware of:
 
-- @apifest.external - the endpoint visible to the world;
-- @apifest.internal - your API endpoint;
-- @apifest.action - the class name of the action that will be executed before requests hit your API;
-- @apifest.filter - the class name of the filter that will be executed before responses from API are returned back;
-- @apifest.scope - scope(s)(space-separated list) of the endpoint;
+- @apifest.external - the endpoint visible to the world.
+- @apifest.internal - your API endpoint.
+- @apifest.hidden - when added, that endpoint will not be included in the mappings.
+- @apifest.action - the class name of the action that will be executed before requests hit your API.
+- @apifest.filter - the class name of the filter that will be executed before responses from API are returned back.
+- @apifest.scope - scope(s)(space-separated list) of the endpoint.
 - @apifest.auth.type - *user* if user authentication is required, *client-app* if only client application authentication is required. 
-Note, that if the endpoint could be accessible without access token, then just skip this tag;
+Note, that if the endpoint could be accessible without access token, then just skip this tag.
 - @apifest.re.{varName} - regular expression used for variable with name {varName} (without brackets); if several variables, then
 add @apifest.re.{varName} for each of them.
-- @apifest.docs.description - long text description for the endpoint. 
+- @apifest.docs.description - long text description for the endpoint.
 - @apifest.docs.summary - short text description for the endpoint.
-- @apifest.docs.group - can be used to group endpoints.
+- @apifest.docs.group - can be used to group endpoints. 
+- @apifest.docs.hidden - when added, that endpoint won't be included in the mapping documentation.
 
 Currently, JAX-RS HTTP method annotations are used for setting the HTTP method of the endpoint.
 
@@ -93,6 +95,7 @@ If your project uses maven, here is an example integration of ApiFest Doclet in 
                   <additionalJOptions>
                     <additionalJOption>-J-Dmapping.version=${mapping.version}</additionalJOption>
                     <additionalJOption>-J-Dmapping.filename=${mapping.filename}</additionalJOption>
+                    <additionalJOption>-J-Dmapping.docs.filename=${mapping.docs.filename}</additionalJOption>
                     <additionalJOption>-J-Dbackend.host=${backend.host}</additionalJOption>
                     <additionalJOption>-J-Dbackend.port=${backend.port}</additionalJOption>
                     <additionalJOption>-J-Dapplication.path=${application.path}</additionalJOption>
@@ -112,7 +115,7 @@ If your project uses maven, here is an example integration of ApiFest Doclet in 
 ...
 ```
 
-where *backend.host*, *backend.port* and *mode* are defined in *project.properties* file; *mapping.version* and *mapping.filename* 
+where *backend.host*, *backend.port* and *mode* are defined in *project.properties* file; *mapping.version*, *mapping.filename* and *mapping.docs.filename* 
 could be defined in your pom.xml file so they stick to the code. *application.path* is the application path used to 
 obtain all application resources.
 Then you can use the following command in order to generate mapping xml file:

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.apifest</groupId>
   <artifactId>apifest-doclet</artifactId>
-  <version>0.1.1-SNAPSHOT</version>
+  <version>0.1.2-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -11,6 +11,26 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-netty</artifactId>
+      <version>3.0.9.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+      <version>3.0.9.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <version>3.0.9.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <version>1.1.1</version>
+    </dependency>
     <dependency>
       <groupId>com.sun</groupId>
       <artifactId>tools</artifactId>
@@ -21,7 +41,30 @@
     <dependency>
       <groupId>com.apifest</groupId>
       <artifactId>apifest-api</artifactId>
-      <version>0.1.1</version>
+      <version>0.1.2-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jaxb-annotations</artifactId>
+      <version>2.5.0</version>
+    </dependency>
+    <!-- Test Scope -->
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>6.8.21</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.0.2-beta</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.restfb</groupId>
+      <artifactId>restfb</artifactId>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,21 +15,25 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-netty</artifactId>
       <version>3.0.9.Final</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson2-provider</artifactId>
       <version>3.0.9.Final</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
       <version>3.0.9.Final</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
       <version>1.1.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.sun</groupId>
@@ -58,13 +62,8 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.0.2-beta</version>
+      <version>1.10.19</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.restfb</groupId>
-      <artifactId>restfb</artifactId>
-      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/apifest/doclet/Doclet.java
+++ b/src/main/java/com/apifest/doclet/Doclet.java
@@ -17,10 +17,17 @@
 package com.apifest.doclet;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,8 +39,17 @@ import com.apifest.api.Mapping;
 import com.apifest.api.Mapping.Backend;
 import com.apifest.api.Mapping.EndpointsWrapper;
 import com.apifest.api.MappingAction;
+import com.apifest.api.MappingDocumentation;
 import com.apifest.api.MappingEndpoint;
+import com.apifest.api.MappingEndpointDocumentation;
 import com.apifest.api.ResponseFilter;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.sun.javadoc.AnnotationDesc;
 import com.sun.javadoc.ClassDoc;
 import com.sun.javadoc.MethodDoc;
@@ -41,8 +57,8 @@ import com.sun.javadoc.RootDoc;
 import com.sun.javadoc.Tag;
 
 /**
- * Parse Javadoc tags and create output mapping file.
- * HTTP methods are extracted from JAX-RS annotations.
+ * Parse Javadoc tags and create output mapping file. HTTP methods are extracted
+ * from JAX-RS annotations.
  *
  * @author Rossitsa Borissova
  */
@@ -53,18 +69,22 @@ public class Doclet {
     private static final String APIFEST_ACTION = "apifest.action";
     private static final String APIFEST_FILTER = "apifest.filter";
     private static final String APIFEST_SCOPE = "apifest.scope";
+    private static final String APIFEST_HIDDEN = "apifest.hidden";
     private static final String APIFEST_RE = "apifest.re.";
     private static final String APIFEST_BACKEND_HOST = "apifest.backend.host";
     private static final String APIFEST_BACKEND_PORT = "apifest.backend.port";
     private static final Pattern VAR_PATTERN = Pattern.compile("(\\{)(\\w*-?_?\\w*)(\\})");
+    private static final String APIFEST_DOCS_DESCRIPTION = "apifest.docs.description";
+    private static final String APIFEST_DOCS_SUMMARY = "apifest.docs.summary";
+    private static final String APIFEST_DOCS_GROUP = "apifest.docs.group";
+    private static final String APIFEST_DOCS_HIDDEN = "apifest.docs.hidden";
 
-    // returned when a variable is missing in the properties file and then passed to the Doclet as env variable
+    // returned when a variable is missing in the properties file and then
+    // passed to the Doclet as env variable
     private static final String NULL = "null";
 
     // valid values: user or client-app
     private static final String APIFEST_AUTH_TYPE = "apifest.auth.type";
-
-    private static List<MappingEndpoint> endpoints = new ArrayList<MappingEndpoint>();
 
     private static String mappingVersion;
 
@@ -72,7 +92,9 @@ public class Doclet {
 
     private static Integer backendPort;
 
-    private static String outputFile;
+    private static String mappingOutputFile;
+
+    private static String mappingDocsOutputFile;
 
     private static String applicationPath;
 
@@ -82,78 +104,314 @@ public class Doclet {
     // if no filter is declared, use that
     private static String defaultFilterClass;
 
+    private static Set<DocletMode> docletMode = new HashSet<DocletMode>();
+
     private static final String DEFAULT_MAPPING_NAME = "output_mapping_%s.xml";
 
     private static final String NOT_SUPPORTED_VALUE = "value \"%s\" not supported for %s tag";
 
     // GET, POST, PUT, DELETE, HEAD, OPTIONS
-    private static List<String> httpMethods = Arrays.asList("javax.ws.rs.GET", "javax.ws.rs.POST",
-            "javax.ws.rs.PUT", "javax.ws.rs.DELETE", "javax.ws.rs.HEAD", "javax.ws.rs.OPTIONS");
+    private static List<String> httpMethods = Arrays.asList("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS");
+
+    /**
+     * Starts the doclet from the command line.
+     *
+     * @param args
+     *            List of all the packages that need to be processed.
+     */
+    public static void main(String[] args) {
+        Doclet.cofigureDocletProperties();
+        String[] docletArgs = Doclet.getDocletArgs(args);
+        com.sun.tools.javadoc.Main.execute(docletArgs);
+    }
 
     public static boolean start(RootDoc root) {
-        mappingVersion = System.getProperty("mapping.version");
-        if(mappingVersion == null || mappingVersion.isEmpty() || NULL.equals(mappingVersion)) {
-            System.out.println("ERROR: mapping.version is not set");
-            return false;
-        }
-
-        backendHost = System.getProperty("backend.host");
-        if(backendHost == null || backendHost.length() == 0 || NULL.equals(backendHost)) {
-            System.out.println("ERROR: backend.host is not set");
-            return false;
-        }
-
-        String backendPortStr = System.getProperty("backend.port");
-        if(backendPortStr == null || backendPortStr.length() == 0 || NULL.equals(backendPort)) {
-            System.out.println("ERROR: backend.port is not set");
-            return false;
-        }
-
         try {
-            backendPort = Integer.valueOf(backendPortStr);
-        } catch (NumberFormatException e) {
-            System.out.println("ERROR: backendPort is not an integer");
+            validateConfiguration();
+        } catch (IllegalArgumentException ex) {
+            System.out.println("ERROR: " + ex.getMessage());
             return false;
         }
-
-        defaultActionClass = System.getProperty("defaultActionClass");
-
-        defaultFilterClass = System.getProperty("defaultFilterClass");
-
-        outputFile = System.getProperty("mapping.filename");
-
-        applicationPath = System.getProperty("application.path");
 
         System.out.println("Start ApiFest Doclet>>>>>>>>>>>>>>>>>>>");
         System.out.println("mapping.version is: " + System.getProperty("mapping.version"));
-        System.out.println("backend.host: " + System.getProperty("backend.host"));
-        System.out.println("backend.port: " + System.getProperty("backend.port"));
 
         try {
+            List<ParsedEndpoint> parsedEndpoints = new ArrayList<ParsedEndpoint>();
             ClassDoc[] classes = root.classes();
             for (ClassDoc clazz : classes) {
                 MethodDoc[] mDocs = clazz.methods();
                 for (MethodDoc doc : mDocs) {
-                    MappingEndpoint endpoint = getMappingEndpoint(doc);
-                    if(endpoint != null) {
-                        endpoints.add(endpoint);
+                    ParsedEndpoint parsed = parseEndpoint(doc);
+                    if (parsed != null) {
+                        parsedEndpoints.add(parsed);
                     }
                 }
             }
-
-            generateMappingFile(outputFile);
-        } catch (JAXBException e) {
-            System.out.println("ERROR: cannot create mapping file, " + e.getMessage());
-            return false;
+            if (docletMode.contains(DocletMode.DOC)) {
+                generateDocsFile(parsedEndpoints, mappingDocsOutputFile);
+            }
+            if (docletMode.contains(DocletMode.MAPPING)) {
+                generateMappingFile(parsedEndpoints, mappingOutputFile);
+            }
+            return true;
         } catch (ParseException e) {
             System.out.println("ERROR: cannot create mapping file, " + e.getMessage());
             return false;
+        } catch (JsonGenerationException e) {
+            System.out.println("ERROR: cannot create mapping file, " + e.getMessage());
+            return false;
+        } catch (JsonMappingException e) {
+            System.out.println("ERROR: cannot create mapping file, " + e.getMessage());
+            return false;
+        } catch (IOException e) {
+            System.out.println("ERROR: cannot create mapping file, " + e.getMessage());
+            return false;
+        } catch (JAXBException e) {
+            System.out.println("ERROR: cannot create mapping file, " + e.getMessage());
+            return false;
         }
-        return true;
     }
 
-    private static void generateMappingFile(String outputFile) throws JAXBException {
-        if(outputFile == null || outputFile.length() == 0 || NULL.equals(outputFile)) {
+    private static void validateConfiguration() {
+        String modeInput = System.getProperty("mode");
+        if (modeInput == null) {
+            throw new IllegalArgumentException("mode is invalid.");
+        }
+        String[] modesSplit = modeInput.split(",");
+        for (String modeSplit : modesSplit) {
+            DocletMode mode = DocletMode.fromString(modeSplit);
+            if (mode == null) {
+                throw new IllegalArgumentException("One of the modes you have specified is invalid: " + modeSplit);
+            }
+            docletMode.add(mode);
+        }
+        mappingVersion = System.getProperty("mapping.version");
+        if (mappingVersion == null || mappingVersion.isEmpty() || NULL.equals(mappingVersion)) {
+            throw new IllegalArgumentException("mapping.version is not set.");
+        }
+        if (docletMode.contains(DocletMode.MAPPING)) {
+            backendHost = System.getProperty("backend.host");
+            if (backendHost == null || backendHost.length() == 0 || NULL.equals(backendHost)) {
+                throw new IllegalArgumentException("backend.host is not set.");
+            }
+            String backendPortStr = System.getProperty("backend.port");
+            if (backendPortStr == null || backendPortStr.length() == 0 || NULL.equals(backendPort)) {
+                System.out.println("ERROR: backend.port is not set");
+                throw new IllegalArgumentException("backend.host is not set.");
+            }
+            try {
+                backendPort = Integer.valueOf(backendPortStr);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("backendPort is not an integer.");
+            }
+            defaultActionClass = System.getProperty("defaultActionClass");
+            defaultFilterClass = System.getProperty("defaultFilterClass");
+        }
+        mappingOutputFile = System.getProperty("mapping.filename");
+        if (docletMode.contains(DocletMode.MAPPING) && (mappingOutputFile == null || mappingOutputFile.isEmpty())) {
+            throw new IllegalArgumentException("the mappings output file must be provided.");
+        }
+        mappingDocsOutputFile = System.getProperty("mapping.docs.filename");
+        if (docletMode.contains(DocletMode.DOC) && (mappingDocsOutputFile == null || mappingDocsOutputFile.isEmpty())) {
+            throw new IllegalArgumentException("the mappings docs output file must be provided.");
+        }
+        applicationPath = System.getProperty("application.path");
+    }
+
+    private static ParsedEndpoint parseEndpoint(MethodDoc methodDoc) throws ParseException {
+        ParsedEndpoint parsed = null;
+        MappingEndpoint mappingEndpoint = null;
+        MappingEndpointDocumentation mappingEndpointDocumentation = null;
+
+        String externalEndpoint = getFirstTag(methodDoc, APIFEST_EXTERNAL);
+        if (externalEndpoint != null) {
+
+            parsed = new ParsedEndpoint();
+            mappingEndpoint = new MappingEndpoint();
+            mappingEndpointDocumentation = new MappingEndpointDocumentation();
+
+            mappingEndpoint.setExternalEndpoint("/" + mappingVersion + externalEndpoint);
+            mappingEndpointDocumentation.setEndpoint("/" + mappingVersion + externalEndpoint);
+
+            parseInternalEndpointTag(methodDoc, mappingEndpoint);
+            parseDocsGroupTag(methodDoc, mappingEndpointDocumentation);
+            parseDocsSummaryTap(methodDoc, mappingEndpointDocumentation);
+            parseDocsDescriptionTag(methodDoc, mappingEndpointDocumentation);
+            parseScopeTag(methodDoc, mappingEndpoint, mappingEndpointDocumentation);
+            parseActionTag(methodDoc, mappingEndpoint);
+            parseFilterTag(methodDoc, mappingEndpoint);
+            parseAuthTypeTag(methodDoc, mappingEndpoint);
+            parseEndpointBackendTags(methodDoc, mappingEndpoint);
+            parseHidden(methodDoc, mappingEndpoint, mappingEndpointDocumentation);
+            parseMethodAnnotations(methodDoc, mappingEndpoint, mappingEndpointDocumentation);
+        }
+
+        if (parsed != null) {
+            if (mappingEndpoint != null) {
+                parsed.setMappingEndpoint(mappingEndpoint);
+            }
+            if (mappingEndpointDocumentation != null) {
+                parsed.setMappingEndpointDocumentation(mappingEndpointDocumentation);
+            }
+        }
+
+        return parsed;
+    }
+
+    private static void parseMethodAnnotations(MethodDoc methodDoc, MappingEndpoint mappingEndpoint, MappingEndpointDocumentation mappingEndpointDocumentation) {
+        AnnotationDesc[] annotations = methodDoc.annotations();
+        for (AnnotationDesc a : annotations) {
+            if (a != null && (httpMethods.contains(a.annotationType().name()))) {
+                String annotationTypeName = a.annotationType().name();
+                mappingEndpoint.setMethod(annotationTypeName);
+                mappingEndpointDocumentation.setMethod(annotationTypeName);
+            }
+        }
+    }
+
+    private static void parseEndpointBackendTags(MethodDoc methodDoc, MappingEndpoint mappingEndpoint) {
+        String endpointBackendHost = getFirstTag(methodDoc, APIFEST_BACKEND_HOST);
+        String endpointBackendPort = getFirstTag(methodDoc, APIFEST_BACKEND_PORT);
+        if (endpointBackendHost != null && endpointBackendPort != null) {
+            try {
+                int port = Integer.valueOf(endpointBackendPort);
+                mappingEndpoint.setBackendHost(endpointBackendHost);
+                mappingEndpoint.setBackendPort(port);
+            } catch (NumberFormatException e) {
+                System.out.println("ERROR: apifest.backend.port " + mappingEndpoint.getExternalEndpoint() + " for endpoint is not valid, "
+                        + "default backend host and port will be used");
+            }
+        }
+    }
+
+    private static void parseAuthTypeTag(MethodDoc methodDoc, MappingEndpoint mappingEndpoint) throws ParseException {
+        String authType = getFirstTag(methodDoc, APIFEST_AUTH_TYPE);
+        if (authType != null) {
+            if (MappingEndpoint.AUTH_TYPE_USER.equals(authType) || MappingEndpoint.AUTH_TYPE_CLIENT_APP.equals(authType)) {
+                mappingEndpoint.setAuthType(authType);
+            } else {
+                throw new ParseException(String.format(NOT_SUPPORTED_VALUE, authType, APIFEST_AUTH_TYPE), 0);
+            }
+        }
+    }
+
+    private static void parseFilterTag(MethodDoc methodDoc, MappingEndpoint mappingEndpoint) {
+        String filtersTag = getFirstTag(methodDoc, APIFEST_FILTER);
+        if (filtersTag != null) {
+            ResponseFilter filter = new ResponseFilter();
+            filter.setFilterClassName(filtersTag);
+            mappingEndpoint.setFilters(filter);
+        } else {
+            if (defaultFilterClass != null) {
+                ResponseFilter filter = new ResponseFilter();
+                filter.setFilterClassName(defaultFilterClass);
+                mappingEndpoint.setFilters(filter);
+            }
+        }
+    }
+
+    private static void parseActionTag(MethodDoc methodDoc, MappingEndpoint mappingEndpoint) {
+        String actionsTag = getFirstTag(methodDoc, APIFEST_ACTION);
+        if (actionsTag != null) {
+            MappingAction action = new MappingAction();
+            action.setActionClassName(actionsTag);
+            mappingEndpoint.setAction(action);
+        } else {
+            if (defaultActionClass != null) {
+                MappingAction action = new MappingAction();
+                action.setActionClassName(defaultActionClass);
+                mappingEndpoint.setAction(action);
+            }
+        }
+    }
+
+    private static void parseScopeTag(MethodDoc methodDoc, MappingEndpoint mappingEndpoint, MappingEndpointDocumentation mappingEndpointDocumentation) {
+        String scope = getFirstTag(methodDoc, APIFEST_SCOPE);
+        if (scope != null) {
+            mappingEndpoint.setScope(scope);
+            mappingEndpointDocumentation.setScope(scope);
+        }
+    }
+
+    private static void parseDocsDescriptionTag(MethodDoc methodDoc, MappingEndpointDocumentation mappingEndpointDocumentation) {
+        String docsDecsription = getFirstTag(methodDoc, APIFEST_DOCS_DESCRIPTION);
+        if (docsDecsription != null) {
+            mappingEndpointDocumentation.setDescription(docsDecsription);
+        }
+    }
+
+    private static void parseDocsSummaryTap(MethodDoc methodDoc, MappingEndpointDocumentation mappingEndpointDocumentation) {
+        String docsSummary = getFirstTag(methodDoc, APIFEST_DOCS_SUMMARY);
+        if (docsSummary != null) {
+            mappingEndpointDocumentation.setSummary(docsSummary);
+        }
+    }
+
+    private static void parseDocsGroupTag(MethodDoc methodDoc, MappingEndpointDocumentation mappingEndpointDocumentation) {
+        String docsGroup = getFirstTag(methodDoc, APIFEST_DOCS_GROUP);
+        if (docsGroup != null) {
+            mappingEndpointDocumentation.setGroup(docsGroup);
+        }
+    }
+
+    private static void parseHidden(MethodDoc methodDoc, MappingEndpoint mappingEndpoint, MappingEndpointDocumentation mappingEndpointDocumentation) {
+        boolean isHidden = getFirstTag(methodDoc, APIFEST_HIDDEN) != null;
+        mappingEndpoint.setHidden(isHidden);
+        isHidden = getFirstTag(methodDoc, APIFEST_DOCS_HIDDEN) != null;
+        mappingEndpointDocumentation.setHidden(isHidden);
+    }
+
+    private static void parseInternalEndpointTag(MethodDoc methodDoc, MappingEndpoint mappingEndpoint) {
+        String internalEndpoint = getFirstTag(methodDoc, APIFEST_INTERNAL);
+        if (internalEndpoint != null) {
+            if (applicationPath == null || applicationPath.isEmpty() || NULL.equals(applicationPath)) {
+                mappingEndpoint.setInternalEndpoint(internalEndpoint);
+            } else {
+                mappingEndpoint.setInternalEndpoint(applicationPath + internalEndpoint);
+            }
+            Matcher m = VAR_PATTERN.matcher(internalEndpoint);
+            while (m.find()) {
+                String varName = m.group(2);
+                // get RE if any var in internal path
+                String varExpression = getFirstTag(methodDoc, APIFEST_RE + varName);
+                if (varExpression != null) {
+                    if (mappingEndpoint.getVarName() == null) {
+                        mappingEndpoint.setVarName(varName);
+                        mappingEndpoint.setVarExpression(varExpression);
+                    } else {
+                        // add current varName and varExpression with SPACE
+                        // before that
+                        mappingEndpoint.setVarName(mappingEndpoint.getVarName() + " " + varName);
+                        mappingEndpoint.setVarExpression(mappingEndpoint.getVarExpression() + " " + varExpression);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void generateDocsFile(List<ParsedEndpoint> parsedEndpoints, String outputFile) throws JsonGenerationException, JsonMappingException,
+            IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        AnnotationIntrospector introspector = new JaxbAnnotationIntrospector(TypeFactory.defaultInstance());
+        mapper.setAnnotationIntrospector(introspector);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        MappingDocumentation mappingDocs = new MappingDocumentation();
+        List<MappingEndpointDocumentation> endpoints = new ArrayList<MappingEndpointDocumentation>();
+        for (ParsedEndpoint parsed : parsedEndpoints) {
+            MappingEndpointDocumentation endpoint = parsed.getMappingEndpointDocumentation();
+            if (endpoint != null && !endpoint.isHidden()) {
+                endpoints.add(endpoint);
+            }
+        }
+        mappingDocs.setVersion(mappingVersion);
+        mappingDocs.setMappingEndpontDocumentation(endpoints);
+        mapper.writeValue(new File(outputFile), mappingDocs);
+    }
+
+    private static void generateMappingFile(List<ParsedEndpoint> parsedEndpoints, String outputFile) throws JAXBException {
+        if (outputFile == null || outputFile.length() == 0 || NULL.equals(outputFile)) {
             outputFile = String.format(DEFAULT_MAPPING_NAME, mappingVersion);
         }
         JAXBContext jaxbContext = JAXBContext.newInstance(Mapping.class);
@@ -163,107 +421,16 @@ public class Doclet {
         mapping.setVersion(mappingVersion);
         mapping.setBackend(new Backend(backendHost, backendPort));
         EndpointsWrapper ends = new EndpointsWrapper();
+        List<MappingEndpoint> endpoints = new ArrayList<MappingEndpoint>();
+        for (ParsedEndpoint parsed : parsedEndpoints) {
+            MappingEndpoint endpoint = parsed.getMappingEndpoint();
+            if (endpoint != null && !endpoint.isHidden()) {
+                endpoints.add(endpoint);
+            }
+        }
         ends.setEndpoints(endpoints);
         mapping.setEndpointsWrapper(ends);
         marshaller.marshal(mapping, new File(outputFile));
-    }
-
-    private static MappingEndpoint getMappingEndpoint(MethodDoc methodDoc) throws ParseException {
-        MappingEndpoint endpoint = null;
-
-        String externalEndpoint = getFirstTag(methodDoc, APIFEST_EXTERNAL);
-        if(externalEndpoint != null){
-            endpoint = new MappingEndpoint();
-            endpoint.setExternalEndpoint("/" + mappingVersion + externalEndpoint);
-
-            String internalEndpoint = getFirstTag(methodDoc, APIFEST_INTERNAL);
-            if (internalEndpoint != null) {
-                if (applicationPath == null || applicationPath.isEmpty() || NULL.equals(applicationPath)) {
-                    endpoint.setInternalEndpoint(internalEndpoint);
-                } else {
-                    endpoint.setInternalEndpoint(applicationPath + internalEndpoint);
-                }
-                Matcher m = VAR_PATTERN.matcher(internalEndpoint);
-                int i = 1;
-                while(m.find()) {
-                    String varName = m.group(2);
-
-                    //get RE if any var in internal path
-                    String varExpression = getFirstTag(methodDoc, APIFEST_RE + varName);
-                    if(varExpression != null) {
-                        if (endpoint.getVarName() == null) {
-                            endpoint.setVarName(varName);
-                            endpoint.setVarExpression(varExpression);
-                        } else {
-                            // add current varName and varExpression with SPACE before that
-                            endpoint.setVarName(endpoint.getVarName() + " " + varName);
-                            endpoint.setVarExpression(endpoint.getVarExpression() + " " + varExpression);
-                        }
-                    }
-                }
-            }
-
-            String scope = getFirstTag(methodDoc, APIFEST_SCOPE);
-            if (scope != null) {
-                endpoint.setScope(scope);
-            }
-
-            String actionsTag = getFirstTag(methodDoc, APIFEST_ACTION);
-            if (actionsTag != null) {
-                MappingAction action = new MappingAction();
-                action.setActionClassName(actionsTag);
-                endpoint.setAction(action);
-            } else {
-                if (defaultActionClass != null) {
-                    MappingAction action = new MappingAction();
-                    action.setActionClassName(defaultActionClass);
-                    endpoint.setAction(action);
-                }
-            }
-
-            String filtersTag = getFirstTag(methodDoc, APIFEST_FILTER);
-            if (filtersTag != null) {
-                ResponseFilter filter = new ResponseFilter();
-                filter.setFilterClassName(filtersTag);
-                endpoint.setFilters(filter);
-            }  else {
-                if (defaultFilterClass != null) {
-                    ResponseFilter filter = new ResponseFilter();
-                    filter.setFilterClassName(defaultFilterClass);
-                    endpoint.setFilters(filter);
-                }
-            }
-
-            String authType = getFirstTag(methodDoc, APIFEST_AUTH_TYPE);
-            if(authType != null) {
-                if(MappingEndpoint.AUTH_TYPE_USER.equals(authType) || MappingEndpoint.AUTH_TYPE_CLIENT_APP.equals(authType)) {
-                    endpoint.setAuthType(authType);
-                } else {
-                    String errorMsg = String.format(NOT_SUPPORTED_VALUE, authType, APIFEST_AUTH_TYPE);
-                    throw new ParseException(errorMsg, 0);
-                }
-            }
-
-            String endpointBackendHost = getFirstTag(methodDoc, APIFEST_BACKEND_HOST);
-            String endpointBackendPort = getFirstTag(methodDoc, APIFEST_BACKEND_PORT);
-            if(endpointBackendHost != null && endpointBackendPort != null) {
-               try {
-                   int port = Integer.valueOf(endpointBackendPort);
-                   endpoint.setBackendHost(endpointBackendHost);
-                   endpoint.setBackendPort(port);
-               } catch (NumberFormatException e) {
-                   System.out.println("ERROR: apifest.backend.port " + endpoint.getExternalEndpoint() + " for endpoint is not valid, " +  "default backend host and port will be used");
-               }
-            }
-
-            AnnotationDesc[] annotations = methodDoc.annotations();
-            for (AnnotationDesc a : annotations) {
-                if (a != null && (httpMethods.contains(a.annotationType().toString()))) {
-                    endpoint.setMethod(a.annotationType().name());
-                }
-            }
-        }
-        return endpoint;
     }
 
     private static String getFirstTag(MethodDoc methodDoc, String tagName) {
@@ -273,4 +440,53 @@ public class Doclet {
         }
         return null;
     }
+
+    private static String[] getDocletArgs(String[] inputArgs) {
+        String sourcePath = System.getProperty("sourcePath");
+        if (sourcePath == null || sourcePath.isEmpty()) {
+            throw new IllegalArgumentException("sourcePath is invalid.");
+        }
+        String[] argsDoclet = new String[] { "-doclet", Doclet.class.getName(), "-sourcepath", sourcePath };
+        List<String> arguments = new ArrayList<String>();
+        arguments.addAll(Arrays.asList(inputArgs));
+        arguments.addAll(Arrays.asList(argsDoclet));
+        return arguments.toArray(new String[arguments.size()]);
+    }
+
+    private static void cofigureDocletProperties() {
+        String propertiesFilePath = System.getProperty("propertiesFilePath");
+        if (propertiesFilePath == null) {
+            return;
+        }
+        if (propertiesFilePath.isEmpty()) {
+            throw new IllegalArgumentException("propertiesFilePath is invalid.");
+        }
+        Properties docletProps = Doclet.loadDocletProperties(propertiesFilePath);
+        Enumeration<?> e = docletProps.propertyNames();
+        while (e.hasMoreElements()) {
+            String key = (String) e.nextElement();
+            System.setProperty(key, docletProps.getProperty(key));
+        }
+    }
+
+    private static Properties loadDocletProperties(String filePath) {
+        Properties props = new Properties();
+        InputStream input = null;
+        try {
+            input = new FileInputStream(filePath);
+            props.load(input);
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        } finally {
+            if (input != null) {
+                try {
+                    input.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return props;
+    }
+
 }

--- a/src/main/java/com/apifest/doclet/Doclet.java
+++ b/src/main/java/com/apifest/doclet/Doclet.java
@@ -159,7 +159,7 @@ public class Doclet {
             System.out.println("ERROR: cannot create mapping file, " + e.getMessage());
             return false;
         } catch (JsonGenerationException e) {
-            System.out.println("ERROR: cannot create mapping file, " + e.getMessage());
+            System.out.println("ERROR: cannot create mapping documentation file, " + e.getMessage());
             return false;
         } catch (JsonMappingException e) {
             System.out.println("ERROR: cannot create mapping file, " + e.getMessage());
@@ -176,7 +176,7 @@ public class Doclet {
     private static void validateConfiguration() {
         String modeInput = System.getProperty("mode");
         if (modeInput == null) {
-            throw new IllegalArgumentException("mode is invalid.");
+            modeInput = "mapping";
         }
         String[] modesSplit = modeInput.split(",");
         for (String modeSplit : modesSplit) {
@@ -236,7 +236,7 @@ public class Doclet {
 
             parseInternalEndpointTag(methodDoc, mappingEndpoint);
             parseDocsGroupTag(methodDoc, mappingEndpointDocumentation);
-            parseDocsSummaryTap(methodDoc, mappingEndpointDocumentation);
+            parseDocsSummaryTag(methodDoc, mappingEndpointDocumentation);
             parseDocsDescriptionTag(methodDoc, mappingEndpointDocumentation);
             parseScopeTag(methodDoc, mappingEndpoint, mappingEndpointDocumentation);
             parseActionTag(methodDoc, mappingEndpoint);
@@ -341,7 +341,7 @@ public class Doclet {
         }
     }
 
-    private static void parseDocsSummaryTap(MethodDoc methodDoc, MappingEndpointDocumentation mappingEndpointDocumentation) {
+    private static void parseDocsSummaryTag(MethodDoc methodDoc, MappingEndpointDocumentation mappingEndpointDocumentation) {
         String docsSummary = getFirstTag(methodDoc, APIFEST_DOCS_SUMMARY);
         if (docsSummary != null) {
             mappingEndpointDocumentation.setSummary(docsSummary);
@@ -406,7 +406,7 @@ public class Doclet {
             }
         }
         mappingDocs.setVersion(mappingVersion);
-        mappingDocs.setMappingEndpontDocumentation(endpoints);
+        mappingDocs.setMappingEndpointDocumentation(endpoints);
         mapper.writeValue(new File(outputFile), mappingDocs);
     }
 

--- a/src/main/java/com/apifest/doclet/DocletMode.java
+++ b/src/main/java/com/apifest/doclet/DocletMode.java
@@ -1,0 +1,24 @@
+package com.apifest.doclet;
+
+public enum DocletMode {
+    MAPPING("mapping"), DOC("doc");
+    private String mode;
+
+    private DocletMode(String mode) {
+        this.mode = mode;
+    }
+
+    public String getValue() {
+        return this.mode;
+    }
+
+    public static DocletMode fromString(String value) {
+        DocletMode[] modes = DocletMode.values();
+        for (DocletMode mode : modes) {
+            if (mode.getValue().equalsIgnoreCase(value)) {
+                return mode;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/apifest/doclet/DocletMode.java
+++ b/src/main/java/com/apifest/doclet/DocletMode.java
@@ -1,5 +1,26 @@
+/*
+* Copyright 2013-2015, ApiFest project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 package com.apifest.doclet;
 
+/**
+ * Contains all the doclet modes.
+ * @author Ivan Georgiev
+ *
+ */
 public enum DocletMode {
     MAPPING("mapping"), DOC("doc");
     private String mode;

--- a/src/main/java/com/apifest/doclet/ParsedEndpoint.java
+++ b/src/main/java/com/apifest/doclet/ParsedEndpoint.java
@@ -1,0 +1,21 @@
+package com.apifest.doclet;
+
+import com.apifest.api.MappingEndpoint;
+import com.apifest.api.MappingEndpointDocumentation;
+
+public class ParsedEndpoint {
+    private MappingEndpoint mappingEndpoint;
+    private MappingEndpointDocumentation mappingEndpointDocumentation;
+    public MappingEndpoint getMappingEndpoint() {
+        return mappingEndpoint;
+    }
+    public void setMappingEndpoint(MappingEndpoint mappingEndpoint) {
+        this.mappingEndpoint = mappingEndpoint;
+    }
+    public MappingEndpointDocumentation getMappingEndpointDocumentation() {
+        return mappingEndpointDocumentation;
+    }
+    public void setMappingEndpointDocumentation(MappingEndpointDocumentation mappingEndpointDocumentation) {
+        this.mappingEndpointDocumentation = mappingEndpointDocumentation;
+    }
+}

--- a/src/main/java/com/apifest/doclet/ParsedEndpoint.java
+++ b/src/main/java/com/apifest/doclet/ParsedEndpoint.java
@@ -1,8 +1,29 @@
+/*
+* Copyright 2013-2015, ApiFest project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 package com.apifest.doclet;
 
 import com.apifest.api.MappingEndpoint;
 import com.apifest.api.MappingEndpointDocumentation;
 
+/**
+ * Holds all the parsed data for an endpoint.
+ * @author Ivan Georgiev
+ *
+ */
 public class ParsedEndpoint {
     private MappingEndpoint mappingEndpoint;
     private MappingEndpointDocumentation mappingEndpointDocumentation;

--- a/src/test/java/com/apifest/doclet/tests/DocletModeTest.java
+++ b/src/test/java/com/apifest/doclet/tests/DocletModeTest.java
@@ -1,3 +1,19 @@
+/*
+* Copyright 2013-2015, ApiFest project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 package com.apifest.doclet.tests;
 
 import java.io.File;
@@ -32,7 +48,7 @@ public class DocletModeTest {
     }
 
     private void runDoclet(String mode) {
-        String filePath = "./src/test/java/com/apifest/doclet/tests/resources/ParsingResource.java";
+        String filePath = "./src/test/java/com/apifest/doclet/tests/resources/TestParsingResource.java";
         Doclet doclet = new Doclet();
         String[] args = new String[] { filePath };
         setMode(mode);
@@ -80,5 +96,4 @@ public class DocletModeTest {
         String directory = "./";
         findFile(directory, name, ".xml");
     }
-
 }

--- a/src/test/java/com/apifest/doclet/tests/DocletModeTest.java
+++ b/src/test/java/com/apifest/doclet/tests/DocletModeTest.java
@@ -1,0 +1,84 @@
+package com.apifest.doclet.tests;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+
+import org.json.simple.parser.ParseException;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.apifest.doclet.Doclet;
+
+public class DocletModeTest {
+    @BeforeMethod
+    public void setup() {
+        System.setProperty("sourcePath", "./src/test/java/com/apifest/doclet/tests/resources");
+        System.setProperty("mapping.version", "v1");
+        System.setProperty("mapping.filename", "all-mappings.xml");
+        System.setProperty("mapping.docs.filename", "all-mappings-docs.json");
+        System.setProperty("backend.host", "localhost");
+        System.setProperty("backend.port", "1212");
+        System.setProperty("application.path", "/");
+        System.setProperty("defaultActionClass", "com.all.mappings.DefaultMapping");
+        System.setProperty("defaultFilterClass", "com.all.mappings.DefaultFilter");
+
+    }
+
+    private void setMode(String mode) {
+        System.setProperty("mode", mode);
+    }
+
+    private void runDoclet(String mode) {
+        String filePath = "./src/test/java/com/apifest/doclet/tests/resources/ParsingResource.java";
+        Doclet doclet = new Doclet();
+        String[] args = new String[] { filePath };
+        setMode(mode);
+        Doclet.main(args);
+    }
+
+    private void findFile(String directory, String name, final String extension) {
+        File dir = new File(directory);
+
+        File[] files = dir.listFiles(new FilenameFilter() {
+            public boolean accept(File directory, String fileName) {
+                if (fileName.startsWith("all") && fileName.endsWith(extension)) {
+                    return true;
+                }
+                return false;
+            }
+        });
+        for (File f : files) {
+            Assert.assertEquals(name, f.getName());
+            f.deleteOnExit();
+        }
+    }
+
+    @AfterMethod
+    public void clearProperties() {
+        System.clearProperty("propertiesFilePath");
+    }
+
+    @Test
+    public void when_set_doclet_doc_mode() throws IOException, ParseException {
+        // WHEN
+        runDoclet("doc");
+        // Then
+        String name = "all-mappings-docs.json";
+        String directory = "./";
+        findFile(directory, name, ".json");
+    }
+
+    @Test
+    public void when_set_doclet_mapping_mode() throws IOException, ParseException {
+        // WHEN
+        runDoclet("mapping");
+        // Then
+        String name = "all-mappings.xml";
+        String directory = "./";
+        findFile(directory, name, ".xml");
+    }
+
+}

--- a/src/test/java/com/apifest/doclet/tests/DocletTest.java
+++ b/src/test/java/com/apifest/doclet/tests/DocletTest.java
@@ -1,0 +1,141 @@
+package com.apifest.doclet.tests;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.apifest.doclet.Doclet;
+
+public class DocletTest {
+    @BeforeMethod
+    public void setup() {
+        System.setProperty("sourcePath", "./src/test/java/com/apifest/doclet/tests/resources");
+        System.setProperty("mode", "doc");
+        System.setProperty("mapping.version", "v1");
+        System.setProperty("mapping.filename", "all-mappings.xml");
+        System.setProperty("mapping.docs.filename", "all-mappings-docs.json");
+        System.setProperty("backend.host", "localhost");
+        System.setProperty("backend.port", "1212");
+        System.setProperty(" application.path", "/");
+        System.setProperty("defaultActionClass", "com.all.mappings.DefaultMapping");
+        System.setProperty("defaultFilterClass", "com.all.mappings.DefaultFilter");
+    }
+
+    private void deleteJsonFile(String path) {
+        File f = new File(path);
+        if (f.exists() && f.isFile()) {
+            f.delete();
+        }
+    }
+
+    private void runDoclet() {
+        String filePath = "./src/test/java/com/apifest/doclet/tests/resources/ParsingResource.java";
+        Doclet doclet = new Doclet();
+        String[] args = new String[] { filePath };
+        Doclet.main(args);
+
+    }
+
+    @AfterMethod
+    public void clearProperties() {
+        System.clearProperty("propertiesFilePath");
+    }
+
+    @Test
+    public void when_doclet_run_outputs_tags() throws IOException, ParseException {
+        // GIVEN
+        String parserFilePath = "./all-mappings-docs.json";
+        // WHEN
+        runDoclet();
+        // THEN
+        JSONParser parser = new JSONParser();
+        FileReader fileReader = null;
+        try {
+            fileReader = new FileReader(parserFilePath);
+            JSONObject json = (JSONObject) parser.parse(fileReader);
+            String version = (String) json.get("version");
+            JSONArray arr = (JSONArray) json.get("endpoints");
+            JSONObject obj = (JSONObject) arr.get(0);
+            JSONObject obj1 = (JSONObject) arr.get(1);
+
+            Assert.assertEquals(version, "v1");
+
+            Assert.assertEquals(obj.get("group"), "Twitter Followers");
+            Assert.assertEquals(obj.get("scope"), "twitter_followers");
+            Assert.assertEquals(obj.get("method"), "GET");
+            Assert.assertEquals(obj.get("endpoint"), "/v1/twitter/followers/metrics");
+            Assert.assertEquals(obj.get("description"), null);
+            Assert.assertEquals(obj.get("summary"), null);
+
+            Assert.assertEquals(obj1.get("group"), "Twitter Followers");
+            Assert.assertEquals(obj1.get("scope"), "twitter_followers");
+            Assert.assertEquals(obj1.get("method"), "GET");
+            Assert.assertEquals(obj1.get("endpoint"), "/v1/twitter/followers/stream");
+            Assert.assertNotEquals(obj1.get("description"), null);
+            Assert.assertNotEquals(obj1.get("summary"), null);
+        } finally {
+            if (fileReader != null) {
+                fileReader.close();
+            }
+            deleteJsonFile(parserFilePath);
+        }
+    }
+
+    @Test
+    public void check_whether_json_file_will_generate_unsupported_tags() throws IOException, ParseException {
+        // GIVEN
+        String parserFilePath = "./all-mappings-docs.json";
+        // WHEN
+        runDoclet();
+        // THEN
+        JSONParser parser = new JSONParser();
+        FileReader fileReader = null;
+        try {
+            fileReader = new FileReader(parserFilePath);
+            JSONObject json = (JSONObject) parser.parse(fileReader);
+            JSONArray arr = (JSONArray) json.get("endpoints");
+            JSONObject obj = (JSONObject) arr.get(0);
+            JSONObject obj1 = (JSONObject) arr.get(1);
+            Assert.assertEquals(obj.get("test"), null);
+            Assert.assertEquals(obj1.get("test1"), null);
+        } finally {
+            if (fileReader != null) {
+                fileReader.close();
+            }
+            deleteJsonFile(parserFilePath);
+        }
+    }
+
+    @Test
+    public void check_what_doclet_will_generate_when_tags_are_wrong() throws Exception {
+        // GIVEN
+        String parserFilePath = "./all-mappings-docs.json";
+        // WHEN
+        runDoclet();
+        // THEN
+        JSONParser parser = new JSONParser();
+        FileReader fileReader = null;
+        try {
+            fileReader = new FileReader(parserFilePath);
+            JSONObject json = (JSONObject) parser.parse(fileReader);
+            JSONArray arr = (JSONArray) json.get("endpoints");
+            JSONObject obj = (JSONObject) arr.get(0);
+            Assert.assertEquals(obj.get("wrongtag"), null);
+            Assert.assertEquals(obj.get("@wrongtag"), null);
+        } finally {
+            if (fileReader != null) {
+                fileReader.close();
+            }
+            deleteJsonFile(parserFilePath);
+        }
+    }
+}

--- a/src/test/java/com/apifest/doclet/tests/DocletTest.java
+++ b/src/test/java/com/apifest/doclet/tests/DocletTest.java
@@ -1,3 +1,19 @@
+/*
+* Copyright 2013-2015, ApiFest project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 package com.apifest.doclet.tests;
 
 import java.io.File;
@@ -38,7 +54,7 @@ public class DocletTest {
     }
 
     private void runDoclet() {
-        String filePath = "./src/test/java/com/apifest/doclet/tests/resources/ParsingResource.java";
+        String filePath = "./src/test/java/com/apifest/doclet/tests/resources/TestParsingResource.java";
         Doclet doclet = new Doclet();
         String[] args = new String[] { filePath };
         Doclet.main(args);

--- a/src/test/java/com/apifest/doclet/tests/resources/ParsingResource.java
+++ b/src/test/java/com/apifest/doclet/tests/resources/ParsingResource.java
@@ -1,0 +1,64 @@
+package com.apifest.doclet.tests.resources;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/{platform: komfo|sitecore}/{clientId}/followers")
+public interface ParsingResource {
+
+    /**
+     * @apifest.external /twitter/followers/metrics
+     * @apifest.internal {platform}/{clientId}/followers/metrics
+     * @apifest.scope twitter_followers
+     * @apifest.auth.type client-app
+     * @apifest.re.clientId \d+
+     * @apifest.re.platform \S+
+     * @apifest.docs.group Twitter Followers
+     * @return Response
+     * @test this is any test annotation
+     */
+    @Path("/metrics")
+    @GET
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response getMetrics(@PathParam("clientId") String clientId, @QueryParam("ids") String ids,
+            @QueryParam("fields") String fields, @QueryParam("limit") String limit);
+
+    @Path("/{endpoint: stream|metrics}")
+    @PUT
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response incorrectMethod();
+
+    /**
+     * @apifest.external /twitter/followers/stream
+     * @apifest.internal {platform}/{clientId}/followers/stream
+     * @apifest.scope twitter_followers
+     * @apifest.auth.type client-app
+     * @apifest.re.clientId \d+
+     * @apifest.re.platform \S+
+     * @apifest.docs.group Twitter Followers
+     * @apifest.docs.summary Short summary goes here
+     * @apifest.docs.description Long description goes here Long description goes hereLong description goes here Long description goes hereLong description goes here Long description goes hereLong description goes here Long description goes hereLong description goes here Long description goes hereLong description goes here Long description goes hereLong description goes here Long description goes hereLong description goes here Long description goes hereLong description goes here Long description goes here
+     * @return Response
+     * @test2 this is annotation for testing purpose
+     * #wrongtag
+     * @@wrongtag
+     */
+    @Path("/stream")
+    @GET
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response getStream(@PathParam("clientId") String clientId, @QueryParam("ids") String ids,
+            @QueryParam("fields") String fields, @QueryParam("since") String since, @QueryParam("until") String until, @QueryParam("limit") String limit);
+
+}

--- a/src/test/java/com/apifest/doclet/tests/resources/TestParsingResource.java
+++ b/src/test/java/com/apifest/doclet/tests/resources/TestParsingResource.java
@@ -12,7 +12,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Path("/{platform: komfo|sitecore}/{clientId}/followers")
-public interface ParsingResource {
+public interface TestParsingResource {
 
     /**
      * @apifest.external /twitter/followers/metrics


### PR DESCRIPTION
The doclet can now read docs tags from the endpoint comments and generate documentation json based on those.