### PR TITLE
VarName and VarExpression passed to MappingEndpointDocumentation

### DIFF
--- a/src/main/java/com/apifest/doclet/Doclet.java
+++ b/src/main/java/com/apifest/doclet/Doclet.java
@@ -227,7 +227,7 @@ public class Doclet {
             mappingEndpoint.setExternalEndpoint("/" + mappingVersion + externalEndpoint);
             mappingEndpointDocumentation.setEndpoint("/" + mappingVersion + externalEndpoint);
 
-            Parser.parseInternalEndpointTag(tagMap, mappingEndpoint, applicationPath);
+            Parser.parseInternalEndpointTag(tagMap, mappingEndpoint, mappingEndpointDocumentation, applicationPath);
             Parser.parseDocsDescriptiveTags(tagMap, mappingEndpointDocumentation);
             Parser.parseScopeTag(tagMap, mappingEndpoint, mappingEndpointDocumentation);
             Parser.parseActionTag(tagMap, mappingEndpoint, defaultActionClass);

--- a/src/main/java/com/apifest/doclet/Parser.java
+++ b/src/main/java/com/apifest/doclet/Parser.java
@@ -210,7 +210,6 @@ public class Parser
                     if (mappingEndpoint.getVarName() == null) {
                         mappingEndpoint.setVarName(varName);
                         mappingEndpoint.setVarExpression(varExpression);
-
                     } else {
                         // add current varName and varExpression with SPACE
                         // before that

--- a/src/main/java/com/apifest/doclet/Parser.java
+++ b/src/main/java/com/apifest/doclet/Parser.java
@@ -193,7 +193,7 @@ public class Parser
         mappingEndpointDocumentation.setHidden(isHidden);
     }
 
-    static void parseInternalEndpointTag(Map<String, String> tagMap, MappingEndpoint mappingEndpoint, String applicationPath) {
+    static void parseInternalEndpointTag(Map<String, String> tagMap, MappingEndpoint mappingEndpoint, MappingEndpointDocumentation mappingEndpointDocumentation, String applicationPath) {
         String internalEndpoint = tagMap.get(APIFEST_INTERNAL);
         if (internalEndpoint != null) {
             if (applicationPath == null || applicationPath.isEmpty() || NULL.equals(applicationPath)) {
@@ -210,6 +210,7 @@ public class Parser
                     if (mappingEndpoint.getVarName() == null) {
                         mappingEndpoint.setVarName(varName);
                         mappingEndpoint.setVarExpression(varExpression);
+
                     } else {
                         // add current varName and varExpression with SPACE
                         // before that
@@ -218,6 +219,8 @@ public class Parser
                     }
                 }
             }
+            mappingEndpointDocumentation.setVarExpression(mappingEndpoint.getVarExpression());
+            mappingEndpointDocumentation.setVarName(mappingEndpoint.getVarName());
         }
     }
 

--- a/src/test/java/com/apifest/doclet/ParserTest.java
+++ b/src/test/java/com/apifest/doclet/ParserTest.java
@@ -160,7 +160,7 @@ public class ParserTest {
         String applicationPath = "";
         String internalEndpoint = "/komfo/test/endpoint";
         tagMap.put("apifest.internal", internalEndpoint);
-        Parser.parseInternalEndpointTag(tagMap, mappingEndpoint, applicationPath);
+        Parser.parseInternalEndpointTag(tagMap, mappingEndpoint, mappingEndpointDocumentation, applicationPath);
         Assert.assertEquals(mappingEndpoint.getInternalEndpoint(), internalEndpoint);
     }
 
@@ -170,7 +170,7 @@ public class ParserTest {
         String internalEndpoint = "/komfo/test/endpoint";
         String path = applicationPath + internalEndpoint;
         tagMap.put("apifest.internal", internalEndpoint);
-        Parser.parseInternalEndpointTag(tagMap, mappingEndpoint, applicationPath);
+        Parser.parseInternalEndpointTag(tagMap, mappingEndpoint, mappingEndpointDocumentation, applicationPath);
         Assert.assertEquals(mappingEndpoint.getInternalEndpoint(), path);
     }
 
@@ -179,7 +179,7 @@ public class ParserTest {
         String applicationPath = "test";
         String internalEndpoint = "/komfo/{test}/endpoint";
         tagMap.put("apifest.internal", internalEndpoint);
-        Parser.parseInternalEndpointTag(tagMap, mappingEndpoint, applicationPath);
+        Parser.parseInternalEndpointTag(tagMap, mappingEndpoint, mappingEndpointDocumentation, applicationPath);
         Assert.assertEquals(mappingEndpoint.getVarName(), null);
         Assert.assertEquals(mappingEndpoint.getVarExpression(), null);
     }
@@ -191,7 +191,7 @@ public class ParserTest {
         String pathExpression = "abc";
         tagMap.put("apifest.internal", internalEndpoint);
         tagMap.put("apifest.re.test", pathExpression);
-        Parser.parseInternalEndpointTag(tagMap, mappingEndpoint, applicationPath);
+        Parser.parseInternalEndpointTag(tagMap, mappingEndpoint, mappingEndpointDocumentation, applicationPath);
         Assert.assertEquals(mappingEndpoint.getVarName(), "test");
         Assert.assertEquals(mappingEndpoint.getVarExpression(), pathExpression);
     }


### PR DESCRIPTION
The Parser now passes the VarName and VarExpression of the path params to the MappingEndpointDocumentation.