### PR TITLE
Fixed typo that prevented exampleResult property to be parsed

### DIFF
--- a/src/main/java/com/apifest/doclet/Parser.java
+++ b/src/main/java/com/apifest/doclet/Parser.java
@@ -223,7 +223,7 @@ public class Parser
             mappingEndpointDocumentation.setExampleRequest(exampleRequest);
         }
         String exampleResult = tagMap.get(APIFEST_DOCS_EXAMPLE_RESULT);
-        if (exampleRequest != null) {
+        if (exampleResult != null) {
             mappingEndpointDocumentation.setExampleResult(exampleResult);
         }
 


### PR DESCRIPTION
Fixed typo that prevented exampleResult property to be parsed without exampleRequest property